### PR TITLE
gets Spring MVC path variables passed to React component

### DIFF
--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -8,11 +8,13 @@ class App extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = {logs: []};
+        this.state = {
+            logs: []
+        };
     }
 
     componentDidMount() {
-        client({method: 'GET', path: '/api/logs/staging/Clays-MacBook-Pro.local'}).done(response => {
+        client({method: 'GET', path: '/api/logs/' + this.props.env + '/' + this.props.host}).done(response => {
             this.setState({logs: response.entity});
         });
     }
@@ -28,7 +30,7 @@ class LogList extends React.Component{
     render() {
         var logs = this.props.logs.map(log =>
             <Log key={log.timestamp + log.message} log={log}/>
-    );
+        );
         return (
             <table>
                 <tbody>
@@ -50,7 +52,5 @@ class Log extends React.Component{
     }
 }
 
-ReactDOM.render(
-    <App />,
-    document.getElementById('react')
-)
+var root = document.getElementById('react');
+ReactDOM.render(<App {...(root.dataset)} />, root);

--- a/src/main/kotlin/com/atomist/rolar/ViewResolverController.kt
+++ b/src/main/kotlin/com/atomist/rolar/ViewResolverController.kt
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 @Controller
 class ViewResolverController {
 
-    @RequestMapping("/")
-    fun index(): String {
+    @RequestMapping("logs/{env}/{host}")
+    fun index(@PathVariable env: String, @PathVariable host: String): String {
         return "index"
     }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,9 +7,9 @@
 </head>
 <body>
 
-<div id="react"></div>
+<div id="react" th:data-env="${env}" th:data-host="${host}"></div>
 
-<script src="built/bundle.js"></script>
+<script src="/built/bundle.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
It doesn't look like much, but this subtle magic incantation took a while to figure out. Props have to be semi-redundantly defined as `th:data` atttributes on the element that ReactDOM.render uses, and the dataset for it needs to be spread on the App component. There must be better ways to do this, but this is better than some much more verbose strategies that I started with. Not a lot of documentation for embedded React as a Spring MVC view layer, and what I could find is much simpler than this (nothing passed into the App).
Also, the script source needed a slash at the beginning so that it was an absolute path rather than a relative one. This only mattered once path variables were added to ViewResolverController.index(). It added those to the relative path for bundle.js, couldn't find it there, and returned a 404.